### PR TITLE
fix json marshal/unmarshal methods in string.go

### DIFF
--- a/json.go
+++ b/json.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"errors"
+	jsoniter "github.com/json-iterator/go"
+)
+
+// replace encoding/json with jsoniter
+
+func JsonIter() jsoniter.API {
+	return jsoniter.ConfigCompatibleWithStandardLibrary
+}
+
+// JsonDecode unmarshal
+func JsonDecode(s []byte, data interface{}) (err error) {
+	if len(s) < 1 {
+		return errors.New("nil")
+	}
+	err = JsonIter().Unmarshal(s, &data)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// JsonEncode marshall
+func JsonEncode(data interface{}) (marshal []byte, err error) {
+	marshal, err = JsonIter().Marshal(&data)
+	if err != nil {
+		return
+	}
+	return
+}

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"fmt"
+	"log"
+	"testing"
+)
+
+func TestJsonDecode(t *testing.T) {
+	type user struct {
+		Name string
+		Age  uint8
+	}
+	var u user
+	dataByte := []byte(`{"Age":2,"Name":"James"}`)
+	err := JsonDecode(dataByte, &u)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(u)
+	// Output:
+	// {James 2}
+
+}
+
+func TestJsonEncode(t *testing.T) {
+	var u = struct {
+		Name string
+		Age  uint8
+	}{Name: "James", Age: 2}
+
+	encode, err := JsonEncode(&u)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(encode)
+	fmt.Println(string(encode))
+	// Output:
+	// [123 34 78 97 109 101 34 58 34 74 97 109 101 115 34 44 34 65 103 101 34 58 50 125]
+	// {"Name":"James","Age":2}
+}

--- a/reflect.go
+++ b/reflect.go
@@ -38,7 +38,7 @@ func ReflectToMap(m interface{}, filter []string) map[string]interface{} {
 }
 
 // 将传入的变量转换成接口签名校验需要的格式
-func ReflectToApiSignData(p interface{}) (res []string) {
+func ReflectToApiSignData(p interface{}) (res []string, err error) {
 	t := reflect.TypeOf(p)
 	v := reflect.ValueOf(p)
 
@@ -70,7 +70,12 @@ func ReflectToApiSignData(p interface{}) (res []string) {
 				data[key] = "false"
 			}
 		default:
-			data[key] = JsonEncode(vv)
+			//encode, err := JsonEncode(vv)
+			//if err != nil {
+			//   return
+			//}
+			//data[key] = string(encode)
+			//todo
 		}
 	}
 

--- a/string.go
+++ b/string.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/axgle/mahonia"
-	jsoniter "github.com/json-iterator/go"
 )
 
 func Split(str *string, sep string) []string {
@@ -52,30 +51,6 @@ func StrRR(str *string, subStr string) string {
 
 	pot += len(subStr)
 	return (*str)[pot:]
-}
-
-func JsonIter() jsoniter.API {
-	return jsoniter.ConfigCompatibleWithStandardLibrary
-}
-
-func JsonDecode(s *string, data interface{}) {
-	if *s == "" {
-		return
-	}
-	err := JsonIter().Unmarshal([]byte(*s), &data)
-	if err != nil {
-		//util.ThrowSys("JsonDecode失败:"+err.Error(), *s)
-		//	//	todo
-	}
-}
-
-func JsonEncode(data interface{}) string {
-
-	bs, err := JsonIter().Marshal(data)
-	if err != nil {
-		//util.ThrowSys("jsonEncode失败", data)//	todo
-	}
-	return string(bs)
 }
 
 func Trim(s string) string {


### PR DESCRIPTION
1. Separate json util from string.go.
2. Fix json util method to return error.